### PR TITLE
Fix broken sponsor links

### DIFF
--- a/contribute.njk
+++ b/contribute.njk
@@ -13,7 +13,7 @@ layout: layouts/home.njk
   </div>
   <div class="flex items-center space-x-4 mt-6">
     <a href="https://opencollective.com/bonfire-networks#category-CONTRIBUTE" class="btn btn-primary">Donate</a>
-    <a href="https://opencollective.com/bonfire-networks/contribute/sponsor-39507/checkout" class="btn btn-outline btn-primary">Become a sponsor</a>
+    <a href="https://opencollective.com/bonfire-networks/contribute" class="btn btn-outline btn-primary">Become a sponsor</a>
   </div>
 
   <div class="mt-6 prose prose-lg leading-relaxed text-md text-neutral-content text-opacity-80">

--- a/support_footer.njk
+++ b/support_footer.njk
@@ -37,7 +37,7 @@
           <img class="max-h-12" src="/img/ecf_logo.svg" alt="European Cultural Foundation">
         </div>
         <div class="flex justify-center col-span-1 px-8 py-8 place-content-center bg-white/10">
-          <a class="self-center text-lg font-bold link" href="https://opencollective.com/bonfire-networks/contribute/sponsor-39507/checkout">Become a sponsor</a>
+          <a class="self-center text-lg font-bold link" href="https://opencollective.com/bonfire-networks/contribute">Become a sponsor</a>
         </div>
       </div>
   </div> #}

--- a/zappa.njk
+++ b/zappa.njk
@@ -110,7 +110,7 @@ These interventions may cover ‘technical’, ‘reputational’ and ‘process
     <div class="text-3xl font-bold text-center text-base-content">Project sponsors</div>
     <div class="flex items-center max-w-screen-lg mx-auto mt-8 space-x-4 place-content-center">
         <div class="bg-contain  bg-no-repeat w-40 bg-[url('/img/ecf2.png')] h-20"></div>
-        <a href="https://opencollective.com/bonfire-networks/contribute/sponsor-39507/checkout" class="normal-case btn btn-outline">Become a sponsor</a>
+        <a href="https://opencollective.com/bonfire-networks/contribute" class="normal-case btn btn-outline">Become a sponsor</a>
     </div>
 </div> #}
 


### PR DESCRIPTION
As I'm reading through the website to understand more about the project, I came across the broken links to "Become a Sponsor". It looks like the Open Collective plan for sponsoring has been deleted. So I have replaced it with generic links to show all sponsoring plans, but the core team would know better on which link to be replaced.